### PR TITLE
Adds player profile service reference to abstract game task

### DIFF
--- a/Assets/Prefabs/Game/Game.prefab
+++ b/Assets/Prefabs/Game/Game.prefab
@@ -194,6 +194,9 @@ MonoBehaviour:
   minTimeIntervalBetweenTasks: 10
   randomTimeIntervalSize: 15
   difficulty: {fileID: 2766555538743404404}
+  playerProfileService: {fileID: 0}
+  gameTaskObserver: {fileID: 822869670583254559}
+  integrityObserver: {fileID: 8919326314240518745}
   factories: []
 --- !u!114 &2766555538743404404
 MonoBehaviour:

--- a/Assets/Scripts/Game/FactoryInitializationData.cs
+++ b/Assets/Scripts/Game/FactoryInitializationData.cs
@@ -1,0 +1,20 @@
+using Game.Observer;
+using PlayerController;
+
+namespace Game
+{
+    /// <summary>
+    /// Record class that contains all necessary data for factory initialization and combines game data references
+    /// </summary>
+    /// <param name="difficulty">difficulty reference</param>
+    /// <param name="playerProfileService">player profile service reference</param>
+    /// <param name="gameTaskObserver">game task observer reference</param>
+    /// <param name="integrityObserver">integrity observer reference</param>
+    public record FactoryInitializationData(Difficulty difficulty, PlayerProfileService playerProfileService, GameTaskObserver gameTaskObserver, IntegrityObserver integrityObserver)
+    {
+        public Difficulty difficulty { get; } = difficulty;
+        public PlayerProfileService playerProfileService { get; } = playerProfileService;
+        public GameTaskObserver gameTaskObserver { get; } = gameTaskObserver;
+        public IntegrityObserver integrityObserver { get; } = integrityObserver;
+    }
+}

--- a/Assets/Scripts/Game/FactoryInitializationData.cs.meta
+++ b/Assets/Scripts/Game/FactoryInitializationData.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 11f384cd44e14421bf4e63d6b3f6fa4f
+timeCreated: 1701718106

--- a/Assets/Scripts/Game/Tasks/GameTask.cs
+++ b/Assets/Scripts/Game/Tasks/GameTask.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using PlayerController;
 using UnityEngine;
 
 namespace Game.Tasks
@@ -26,6 +27,12 @@ namespace Game.Tasks
         /// </summary>
         [NonSerialized]
         public Difficulty difficulty;
+        
+        /// <summary>
+        /// Provides the current player profile service instance. This can be used to access the current player
+        /// </summary>
+        [NonSerialized]
+        public PlayerProfileService playerProfileService;
 
         protected TaskState currentTaskState;
         public event Action<GameTask> TaskSuccessful;


### PR DESCRIPTION
The new reference simplifies the access to `PlayerProfileService` instance in task implementation. Furthermore, creating new factories is easier, because the dependencies for the observers are automatically assigned via `GameTimer`.
By using a `FactoryInitializationData` class, the referenced data is exandable and can be changed in future more easily compared to the old structure with serialized fields in abstract game task.