### PR TITLE
Task description display on hud

### DIFF
--- a/Assets/Prefabs/Player/PlayerProfile.prefab
+++ b/Assets/Prefabs/Player/PlayerProfile.prefab
@@ -78,95 +78,84 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 7447489329516643809}
     m_Modifications:
-    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1,
-        type: 3}
+    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1,
-        type: 3}
+    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
       propertyPath: m_LocalPosition.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1,
-        type: 3}
+    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1,
-        type: 3}
+    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1,
-        type: 3}
+    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1,
-        type: 3}
+    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1,
-        type: 3}
+    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1,
-        type: 3}
+    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1,
-        type: 3}
+    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1,
-        type: 3}
+    - target: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2658380546376562028, guid: 79ec5913d0f76524cad289aaf2df60f1,
-        type: 3}
+    - target: {fileID: 2658380546376562028, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
       propertyPath: m_Name
       value: KeyboardPlayer
       objectReference: {fileID: 0}
-    - target: {fileID: 6939289303528413074, guid: 79ec5913d0f76524cad289aaf2df60f1,
-        type: 3}
+    - target: {fileID: 2658380546376562028, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
+      propertyPath: m_TagString
+      value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 6939289303528413074, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
       propertyPath: field of view
       value: 109.3089
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: [{targetCorrespondingSourceObject: {fileID: 2153775653545455729,
-          guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}, insertIndex: -1, addedObject: {
-          fileID: 1078643767615205453}}]
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 2153775653545455729, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1078643767615205453}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
 --- !u!4 &1190962255604273934 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 2153775653545455729, guid: 79ec5913d0f76524cad289aaf2df60f1,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 2153775653545455729, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
   m_PrefabInstance: {fileID: 965065919577908095}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &1254059540207477491 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 2018680082021171596, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
   m_PrefabInstance: {fileID: 965065919577908095}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &2990651091329455635 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 2658380546376562028, guid: 79ec5913d0f76524cad289aaf2df60f1,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 2658380546376562028, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
   m_PrefabInstance: {fileID: 965065919577908095}
   m_PrefabAsset: {fileID: 0}
 --- !u!20 &7866051922799391981 stripped
 Camera:
-  m_CorrespondingSourceObject: {fileID: 6939289303528413074, guid: 79ec5913d0f76524cad289aaf2df60f1,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 6939289303528413074, guid: 79ec5913d0f76524cad289aaf2df60f1, type: 3}
   m_PrefabInstance: {fileID: 965065919577908095}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2566986154514802194
@@ -177,194 +166,164 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 7447489329516643809}
     m_Modifications:
-    - target: {fileID: 2819856895474916288, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 2819856895474916288, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3127728407712097239, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 3127728407712097239, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_Height
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 3127728407712097239, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 3127728407712097239, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_Radius
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3127728407712097239, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 3127728407712097239, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_Center.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3415145736139425353, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 3415145736139425353, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_LocalScale.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_LocalPosition.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6407207605730790461, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 6407207605730790461, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_AutoDeselect
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6407207605730790461, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 6407207605730790461, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_HoverToSelect
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7313654230448209575, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 7313654230448209575, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_Name
       value: VRPlayer (XR Interaction Setup)
       objectReference: {fileID: 0}
-    - target: {fileID: 7696548424635294051, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 7313654230448209575, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
+      propertyPath: m_TagString
+      value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 7696548424635294051, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7696548424635294051, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 7696548424635294051, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7696548424635294051, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 7696548424635294051, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7696548424635294051, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 7696548424635294051, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7696548424635294051, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 7696548424635294051, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9014170783728641054, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 9014170783728641054, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.85
       objectReference: {fileID: 0}
-    - target: {fileID: 9014170783809206330, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 9014170783809206330, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: field of view
       value: 109.3089
       objectReference: {fileID: 0}
-    - target: {fileID: 9168142743249570444, guid: 895f6f3c2d334633b5800312285058d2,
-        type: 3}
+    - target: {fileID: 9168142743249570444, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
       propertyPath: m_MoveSpeed
       value: 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: [{targetCorrespondingSourceObject: {fileID: 9014170783809206335,
-          guid: 895f6f3c2d334633b5800312285058d2, type: 3}, insertIndex: -1, addedObject: {
-          fileID: 8214628122643337786}}]
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 9014170783809206335, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8214628122643337786}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
 --- !u!4 &1945399880720986411 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 4134505312059479865, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
   m_PrefabInstance: {fileID: 2566986154514802194}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &5107246403631356085 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 7313654230448209575, guid: 895f6f3c2d334633b5800312285058d2,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 7313654230448209575, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
   m_PrefabInstance: {fileID: 2566986154514802194}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &5282834843901216626 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 7696548424635294048, guid: 895f6f3c2d334633b5800312285058d2,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 7696548424635294048, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
   m_PrefabInstance: {fileID: 2566986154514802194}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &6793859753166770643 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 9067829889149138881, guid: 895f6f3c2d334633b5800312285058d2,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 9067829889149138881, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
   m_PrefabInstance: {fileID: 2566986154514802194}
   m_PrefabAsset: {fileID: 0}
 --- !u!20 &6811413919242231336 stripped
 Camera:
-  m_CorrespondingSourceObject: {fileID: 9014170783809206330, guid: 895f6f3c2d334633b5800312285058d2,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 9014170783809206330, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
   m_PrefabInstance: {fileID: 2566986154514802194}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &6811413919242231341 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 9014170783809206335, guid: 895f6f3c2d334633b5800312285058d2,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 9014170783809206335, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
   m_PrefabInstance: {fileID: 2566986154514802194}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &6811413919338249902 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 9014170783705847996, guid: 895f6f3c2d334633b5800312285058d2,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 9014170783705847996, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
   m_PrefabInstance: {fileID: 2566986154514802194}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &6811413920940523087 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 9014170785475729501, guid: 895f6f3c2d334633b5800312285058d2,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 9014170785475729501, guid: 895f6f3c2d334633b5800312285058d2, type: 3}
   m_PrefabInstance: {fileID: 2566986154514802194}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3288855368479875684
@@ -375,108 +334,87 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6811413919242231341}
     m_Modifications:
-    - target: {fileID: 3989994248245669121, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 3989994248245669121, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_Name
       value: HUD_Canvas
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_Pivot.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_Pivot.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
@@ -487,8 +425,7 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: d9538bbf19a74751db7efd46af685787, type: 3}
 --- !u!114 &2086237186137108589 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3555470008446915081, guid: d9538bbf19a74751db7efd46af685787,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 3555470008446915081, guid: d9538bbf19a74751db7efd46af685787, type: 3}
   m_PrefabInstance: {fileID: 3288855368479875684}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
@@ -499,8 +436,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
 --- !u!224 &8214628122643337786 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
   m_PrefabInstance: {fileID: 3288855368479875684}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5862693322456465427
@@ -511,108 +447,87 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1190962255604273934}
     m_Modifications:
-    - target: {fileID: 3989994248245669121, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 3989994248245669121, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_Name
       value: HUD_Canvas
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_Pivot.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_Pivot.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-        type: 3}
+    - target: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
@@ -623,14 +538,12 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: d9538bbf19a74751db7efd46af685787, type: 3}
 --- !u!224 &1078643767615205453 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 6891743596625932382, guid: d9538bbf19a74751db7efd46af685787, type: 3}
   m_PrefabInstance: {fileID: 5862693322456465427}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &6920882131679449626 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3555470008446915081, guid: d9538bbf19a74751db7efd46af685787,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 3555470008446915081, guid: d9538bbf19a74751db7efd46af685787, type: 3}
   m_PrefabInstance: {fileID: 5862693322456465427}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}

--- a/Assets/Scenes/SpaceStation.unity
+++ b/Assets/Scenes/SpaceStation.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.031483587, g: 0.009458372, b: 0.013140744, a: 1}
+  m_IndirectSpecularColor: {r: 0.031442195, g: 0.009468702, b: 0.013107872, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -3517,6 +3517,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96df21c3a5fbfb42855a3d689822966, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerNearbyCollider: {fileID: 0}
 --- !u!1 &508178414
 GameObject:
   m_ObjectHideFlags: 0
@@ -3546,6 +3547,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96df21c3a5fbfb42855a3d689822966, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerNearbyCollider: {fileID: 0}
 --- !u!4 &508178416
 Transform:
   m_ObjectHideFlags: 0
@@ -9130,6 +9132,7 @@ GameObject:
   m_Component:
   - component: {fileID: 734668759}
   - component: {fileID: 734668760}
+  - component: {fileID: 734668761}
   m_Layer: 0
   m_Name: MedicalDisasterSpawnPoint1
   m_TagString: Untagged
@@ -9164,6 +9167,28 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96df21c3a5fbfb42855a3d689822966, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerNearbyCollider: {fileID: 734668761}
+--- !u!65 &734668761
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 734668758}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 3, y: 1, z: 3}
+  m_Center: {x: 0, y: 0, z: 1}
 --- !u!1001 &745125224
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13640,6 +13665,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96df21c3a5fbfb42855a3d689822966, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerNearbyCollider: {fileID: 0}
 --- !u!1 &1013114009 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1920449188707948386, guid: ab01648c73795374fa3934222a50eb23, type: 3}
@@ -15627,6 +15653,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96df21c3a5fbfb42855a3d689822966, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerNearbyCollider: {fileID: 0}
 --- !u!1001 &1029942698
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -16116,6 +16143,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96df21c3a5fbfb42855a3d689822966, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerNearbyCollider: {fileID: 0}
 --- !u!1 &1236737386
 GameObject:
   m_ObjectHideFlags: 0
@@ -17128,6 +17156,10 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 3769836651817287872, guid: 0cda5b461e1a3bc4fb95af263ff9f9b0, type: 3}
+      propertyPath: initialGameTime
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 3769836651817287872, guid: 0cda5b461e1a3bc4fb95af263ff9f9b0, type: 3}
       propertyPath: factories.Array.size
       value: 8
       objectReference: {fileID: 0}
@@ -18116,6 +18148,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96df21c3a5fbfb42855a3d689822966, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerNearbyCollider: {fileID: 0}
 --- !u!1001 &1477313347
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -18822,6 +18855,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96df21c3a5fbfb42855a3d689822966, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerNearbyCollider: {fileID: 0}
 --- !u!1001 &1511840716
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -18983,6 +19017,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96df21c3a5fbfb42855a3d689822966, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerNearbyCollider: {fileID: 0}
 --- !u!1 &1530439221
 GameObject:
   m_ObjectHideFlags: 0
@@ -19024,6 +19059,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1532761268}
   - component: {fileID: 1532761269}
+  - component: {fileID: 1532761270}
   m_Layer: 0
   m_Name: MixingIngredientsSpawnPoint1
   m_TagString: Untagged
@@ -19062,6 +19098,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f9382dddbada4c6392b146ee8d366d31, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerNearbyCollider: {fileID: 1532761270}
   recipeSpawnPoint: {fileID: 1162545954}
   ingredientContainerSpawnPoints:
   - {fileID: 2132106275}
@@ -19071,6 +19108,27 @@ MonoBehaviour:
   - {fileID: 1296902297}
   plantToWaterSpawnPoint: {fileID: 117140801}
   wateringBottleSpawnPoint: {fileID: 726439948}
+--- !u!65 &1532761270
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1532761267}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 9.747276, y: 1, z: 3.9018173}
+  m_Center: {x: 4.373638, y: 0, z: 0.17699623}
 --- !u!1001 &1549815486
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -20647,6 +20705,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96df21c3a5fbfb42855a3d689822966, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerNearbyCollider: {fileID: 0}
 --- !u!1001 &1700595996
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -21732,6 +21791,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96df21c3a5fbfb42855a3d689822966, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerNearbyCollider: {fileID: 0}
 --- !u!4 &1719076931 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4024914263291546, guid: 835acc1a9ebe24c0fa3854c99346f9cd, type: 3}
@@ -21912,6 +21972,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96df21c3a5fbfb42855a3d689822966, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerNearbyCollider: {fileID: 0}
 --- !u!1 &1767264025
 GameObject:
   m_ObjectHideFlags: 0
@@ -23434,6 +23495,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e96df21c3a5fbfb42855a3d689822966, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerNearbyCollider: {fileID: 0}
 --- !u!4 &2029090400
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Game/Tasks/TaskSpawnPoint.cs
+++ b/Assets/Scripts/Game/Tasks/TaskSpawnPoint.cs
@@ -1,3 +1,4 @@
+using PlayerController;
 using UnityEngine;
 
 namespace Game.Tasks
@@ -6,10 +7,51 @@ namespace Game.Tasks
     /// Organizes a spawn point to keep track of the current state, whether it is occupied or not.
     /// As this script extends from <see cref="MonoBehaviour"/>, the position of the according game object can serve
     /// as the spawn point position. The position vector can be obtained via <see cref="GetSpawnPosition"/>
+    /// This class also manages the player nearby check using a custom or default collider to display the task
+    /// description on the HUD, when the player is nearby.
     /// </summary>
     public class TaskSpawnPoint : MonoBehaviour
     {
-        public bool isOccupied { get; private set; }
+        /// <summary>
+        /// Default size of the box collider, that is used for player nearby check.
+        /// If no custom collider is set this vector determines the size of the default box collider.
+        /// </summary>
+        private static readonly Vector3 DefaultPlayerNearbyColliderSize = new Vector3(3, 3, 3);
+
+        /// <summary>
+        /// Can be used to setup a custom collider, that should be used for player nearby check.
+        /// If the player is entering this collider, the task description will be shown on the HUD.
+        /// If the player is leaving this collider, the task description will be dismissed.
+        /// If not set, a default box collider will be set at the position of the game task with a fixed size, which is
+        /// determined by the constant <see cref="DefaultPlayerNearbyColliderSize"/>.
+        /// </summary>
+        [SerializeField] protected Collider playerNearbyCollider;
+        
+        /// <summary>
+        /// Keeps track of the current allocated task. Can be null, if no task is allocated currently.
+        /// </summary>
+        private GameTask m_AllocatedTask;
+        
+        /// <summary>
+        /// Returns true, if this spawn point is occupied by a game task and should not be used to spawn another task
+        /// currently
+        /// </summary>
+        public bool isOccupied => m_AllocatedTask != null;
+        
+        private void Start()
+        {
+            // Set up the collider for the player nearby check. Add a default box collider with a fixed size, if no 
+            // custom collider is setup for this spawn point
+            if (playerNearbyCollider == null)
+            {
+                playerNearbyCollider = gameObject.AddComponent<BoxCollider>();
+                ((BoxCollider) playerNearbyCollider).size = DefaultPlayerNearbyColliderSize;
+            }
+            
+            // set collider to trigger to not block player movement
+            playerNearbyCollider.isTrigger = true;
+        }
+        
 
         /// <summary>
         /// Marks the spawn point as occupied and registers the <see cref="GameTask.GameObjectDestroyed"/> action to be
@@ -19,7 +61,7 @@ namespace Game.Tasks
         /// <param name="gameTask">game task, which occupies this spawn point</param>
         public void Allocate(GameTask gameTask)
         {
-            isOccupied = true;
+            m_AllocatedTask = gameTask;
             gameTask.GameObjectDestroyed += Deallocate;
         }
 
@@ -28,9 +70,9 @@ namespace Game.Tasks
         /// </summary>
         public void Deallocate(GameTask gameTask)
         {
-            isOccupied = false;
+            m_AllocatedTask = null;
         }
-
+        
         /// <summary>
         /// Provides the position vector of this spawn point
         /// </summary>
@@ -47,6 +89,26 @@ namespace Game.Tasks
         public Quaternion GetRotation()
         {
             return transform.rotation;
+        }
+        
+        private void OnTriggerEnter(Collider other)
+        {
+            // check if other collider is player
+            if (m_AllocatedTask != null && other.CompareTag(PlayerProfileService.k_PlayerGameObjectTag))
+            {
+                // show task description on HUD
+                m_AllocatedTask.playerProfileService.GetHUD().ChangeText(m_AllocatedTask.taskDescription);
+            }
+        }
+
+        private void OnTriggerExit(Collider other)
+        {
+            // check if other collider is player
+            if (m_AllocatedTask != null && other.CompareTag(PlayerProfileService.k_PlayerGameObjectTag))
+            {
+                // dismiss task description on HUD
+                m_AllocatedTask.playerProfileService.GetHUD().DismissText();
+            }
         }
     }
 }

--- a/Assets/Scripts/PlayerController/PlayerProfileService.cs
+++ b/Assets/Scripts/PlayerController/PlayerProfileService.cs
@@ -1,6 +1,4 @@
-using System;
 using UnityEngine;
-using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
 
 namespace PlayerController
@@ -11,6 +9,7 @@ namespace PlayerController
     /// </summary>
     public class PlayerProfileService : MonoBehaviour
     {
+        public const string k_PlayerGameObjectTag = "Player";
         [SerializeField] private bool isVrPlayerActive;
         [SerializeField] private GameObject vrPlayer;
         [SerializeField] private GameObject xrOrigin;


### PR DESCRIPTION
Adds feature to display task description on `HUD`, when player is nearby a game task.

Task spawn point script now adds a default `BoxCollider`. This collider is set to trigger to not physically interact with the player. 
If a player collides with the trigger (walks into the collider), the task description will be displayed in the `HUD`, which can be toggled with 'I' key on keyboard for debugging purpose.
If a task needs a custom collider, you can add a collider component to the spawn point and assign the created collider in the `TaskSpawnPoint` script. If setup, the custom collider will be used for collision detection.