### PR TITLE
Task spawn enhancement

### DIFF
--- a/Assets/Scripts/Game/FactoryInitializationData.cs
+++ b/Assets/Scripts/Game/FactoryInitializationData.cs
@@ -10,11 +10,13 @@ namespace Game
     /// <param name="playerProfileService">player profile service reference</param>
     /// <param name="gameTaskObserver">game task observer reference</param>
     /// <param name="integrityObserver">integrity observer reference</param>
-    public record FactoryInitializationData(Difficulty difficulty, PlayerProfileService playerProfileService, GameTaskObserver gameTaskObserver, IntegrityObserver integrityObserver)
+    public record FactoryInitializationData(Difficulty difficulty, PlayerProfileService playerProfileService, GameTaskObserver gameTaskObserver, IntegrityObserver integrityObserver, float taskSpawnPointTimeout)
     {
         public Difficulty difficulty { get; } = difficulty;
         public PlayerProfileService playerProfileService { get; } = playerProfileService;
         public GameTaskObserver gameTaskObserver { get; } = gameTaskObserver;
         public IntegrityObserver integrityObserver { get; } = integrityObserver;
+        
+        public float taskSpawnPointTimeout { get; } = taskSpawnPointTimeout;
     }
 }

--- a/Assets/Scripts/Game/GameTimer.cs
+++ b/Assets/Scripts/Game/GameTimer.cs
@@ -18,7 +18,7 @@ namespace Game
         private readonly Logger m_LOG = new Logger(new LogHandler());
         private const string LOGTag = "GameTimer";
 
-        [Header("Timer settings (every value in seconds)")] 
+        [Header("Timer settings")] 
         
         [SerializeField] private float initialGameTime = 60;
         [SerializeField] private float difficultyTimeModifier = 10;
@@ -27,6 +27,8 @@ namespace Game
         // determines the size of the interval from which a random value is used for the next game task time
         // higher values will result in a greater chance of more widely spread time intervals
         [SerializeField] private float randomTimeIntervalSize = 15;
+        
+        [SerializeField] private float taskSpawnPointTimeout = 10;
 
         [Header("Game dependencies")] 
         [SerializeField] private Difficulty difficulty;
@@ -62,7 +64,7 @@ namespace Game
 
             // initialize factories
             var factoryInitializationData = new FactoryInitializationData(difficulty, playerProfileService,
-                gameTaskObserver, integrityObserver);
+                gameTaskObserver, integrityObserver, taskSpawnPointTimeout);
             foreach (var factory in factories)
             {
                 factory.Initialize(factoryInitializationData);

--- a/Assets/Scripts/Game/Observer/GameTaskObserver.cs
+++ b/Assets/Scripts/Game/Observer/GameTaskObserver.cs
@@ -12,6 +12,8 @@ namespace Game.Observer
     {
         private readonly Logger m_LOG = new Logger(new LogHandler());
         private const string LOGTag = "GameTaskObserver";
+
+        private int m_ActiveTasks;
         
         // sound-manager-scripts to play sounds for tasks
         [SerializeField] private SoundManager taskFailureSoundManager;
@@ -22,18 +24,37 @@ namespace Game.Observer
         {
             m_LOG.Log(LOGTag,"task successful: " + task.taskName);
             taskSuccessSoundManager.PlaySound();
+            m_ActiveTasks--;
         }
         
         protected override void OnTaskFailed(GameTask task)
         {
             m_LOG.Log(LOGTag,"task failed: " + task.taskName);
             taskFailureSoundManager.PlaySound();
+            m_ActiveTasks--;
         }
         
         protected override void OnTaskGameObjectDestroyed(GameTask task)
         {
             base.OnTaskGameObjectDestroyed(task);
             m_LOG.Log(LOGTag,"task game object destroyed: " + task.taskName);
+        }
+
+        /// <summary>
+        /// Returns the current active task count.
+        /// </summary>
+        /// <returns>the number of active tasks</returns>
+        public int GetActiveTaskCount()
+        {
+            return m_ActiveTasks;
+        }
+
+        /// <summary>
+        /// Increments the active task counter by 1. Should be called once every time a new task is spawned.
+        /// </summary>
+        public void IncrementActiveTask()
+        {
+            m_ActiveTasks++;
         }
     }
 }

--- a/Assets/Scripts/Game/Tasks/GameTaskFactory.cs
+++ b/Assets/Scripts/Game/Tasks/GameTaskFactory.cs
@@ -62,6 +62,12 @@ namespace Game.Tasks
             m_PlayerProfileService = initializationData.playerProfileService;
             m_GameTaskObserver = initializationData.gameTaskObserver;
             m_IntegrityObserver = initializationData.integrityObserver;
+
+            // set timeout values of all spawn points
+            foreach (var spawnPoint in spawnPoints)
+            {
+                spawnPoint.SetTimeout(initializationData.taskSpawnPointTimeout);
+            }
         }
         
         public override bool TrySpawnTask()
@@ -71,7 +77,7 @@ namespace Game.Tasks
             // search for non-occupied spawn point
             foreach (var spawnPoint in spawnPoints)
             {
-                if (spawnPoint.isOccupied)
+                if (!spawnPoint.CanBeAllocated())
                 {
                     continue;
                 }

--- a/Assets/Scripts/Game/Tasks/TaskSpawnPoint.cs
+++ b/Assets/Scripts/Game/Tasks/TaskSpawnPoint.cs
@@ -31,12 +31,22 @@ namespace Game.Tasks
         /// Keeps track of the current allocated task. Can be null, if no task is allocated currently.
         /// </summary>
         private GameTask m_AllocatedTask;
-        
+
+        private float m_Timeout;
+        private System.DateTime lastDeallocateTime;
+
         /// <summary>
-        /// Returns true, if this spawn point is occupied by a game task and should not be used to spawn another task
-        /// currently
+        /// Returns true, if this spawn point is not occupied by a game task and is not blocked by the
+        /// <see cref="m_Timeout"/>.
         /// </summary>
-        public bool isOccupied => m_AllocatedTask != null;
+        public bool CanBeAllocated()
+        {
+            // check if blocked time is passed since last deallocate time
+            var isBlocked = (System.DateTime.UtcNow - lastDeallocateTime).TotalSeconds < m_Timeout;
+            var isAllocated = m_AllocatedTask != null;
+
+            return !isAllocated && !isBlocked;
+        }
         
         private void Start()
         {
@@ -71,6 +81,7 @@ namespace Game.Tasks
         public void Deallocate(GameTask gameTask)
         {
             m_AllocatedTask = null;
+            lastDeallocateTime = System.DateTime.UtcNow;
         }
         
         /// <summary>
@@ -109,6 +120,16 @@ namespace Game.Tasks
                 // dismiss task description on HUD
                 m_AllocatedTask.playerProfileService.GetHUD().DismissText();
             }
+        }
+
+        /// <summary>
+        /// Sets the timout for this spawn point. The timeout determines, how long a spawn point will be blocked
+        /// before a new task can be allocated.
+        /// </summary>
+        /// <param name="timeout"></param>
+        public void SetTimeout(float timeout)
+        {
+            m_Timeout = timeout;
         }
     }
 }


### PR DESCRIPTION
- adds spawn point timeout, that prevents tasks from spawning at the spawn point, while the timeout is ongoing.
- adds a limit of simultaneously active tasks

These values can be edited in the unity editor as variables of the `GameTask` script.